### PR TITLE
fix: blocks, teams를 nullable로 변경한다

### DIFF
--- a/src/main/kotlin/com/slackbot/reply/dto/ConversationsHistoryResponseDto.kt
+++ b/src/main/kotlin/com/slackbot/reply/dto/ConversationsHistoryResponseDto.kt
@@ -17,8 +17,8 @@ data class Messages(
     @JsonProperty("text") val text: String,
     @JsonProperty("user") val user: String,
     @JsonProperty("ts") val ts: String,
-    @JsonProperty("blocks") val blocks: List<Blocks>,
-    @JsonProperty("team") val team: String,
+    @JsonProperty("blocks") val blocks: List<Blocks>?,
+    @JsonProperty("team") val team: String?,
     @JsonProperty("thread_ts") val threadTs: String?,
     @JsonProperty("reply_count") val replyCount: Int?,
     @JsonProperty("reply_users_count") val replyUsersCount: Int?,
@@ -29,7 +29,7 @@ data class Messages(
 )
 
 data class Blocks(
-    @JsonProperty("type") val type: String,
-    @JsonProperty("block_id") val blockId: String
+    @JsonProperty("type") val type: String?,
+    @JsonProperty("block_id") val blockId: String?
 )
 

--- a/src/main/kotlin/com/slackbot/reply/service/SlackReplyService.kt
+++ b/src/main/kotlin/com/slackbot/reply/service/SlackReplyService.kt
@@ -36,7 +36,7 @@ class SlackReplyService(
 
     fun getSlackConversationsHistory(): ConversationsHistoryResponseDto {
         val latestChat = System.currentTimeMillis()
-        val oldestChat = latestChat - (1000L * 60 * 10)
+        val oldestChat = latestChat - (1000L * 60 * CHAT_HISTORY_TIME_RANGE)
         val getConversationsHistory = slackReadClient
             .findByConversationsHistory(
                 authentication = "Bearer $slackKey",
@@ -79,5 +79,9 @@ class SlackReplyService(
             throw IllegalArgumentException("/chat.postMessage is " +
                     "${writeChatPostThreadMessage.ok}")
         }
+    }
+
+    companion object {
+        private const val CHAT_HISTORY_TIME_RANGE = 10
     }
 }

--- a/src/main/kotlin/com/slackbot/reply/service/SlackReplyService.kt
+++ b/src/main/kotlin/com/slackbot/reply/service/SlackReplyService.kt
@@ -36,7 +36,7 @@ class SlackReplyService(
 
     fun getSlackConversationsHistory(): ConversationsHistoryResponseDto {
         val latestChat = System.currentTimeMillis()
-        val oldestChat = latestChat - (1000L * 60 * CHAT_HISTORY_TIME_RANGE)
+        val oldestChat = latestChat - (1000L * 60 * CHAT_HISTORY_MINUTES_RANGE)
         val getConversationsHistory = slackReadClient
             .findByConversationsHistory(
                 authentication = "Bearer $slackKey",
@@ -82,6 +82,6 @@ class SlackReplyService(
     }
 
     companion object {
-        private const val CHAT_HISTORY_TIME_RANGE = 10
+        private const val CHAT_HISTORY_MINUTES_RANGE = 10
     }
 }


### PR DESCRIPTION
https://github.com/GHGHGHKO/slack-auto-reply/issues/2

문제의 history response body
```json
{
    "type": "message",
    "subtype": "channel_join",
    "ts": "1679484416.381899",
    "user": "somecode",
    "text": "<@somecode> 님이 채널에 참여함",
    "inviter": "somecode"
},
```

parsing 중인 history response body
```json
{
    "client_msg_id": "afbfcb5a-d58a-4bdb-b8dc-dd3b6b37ea9a",
    "type": "message",
    "text": "a",
    "user": "somecode",
    "ts": "1679408970.932769",
    "blocks": [
        {
            "type": "rich_text",
            "block_id": "LUvu2",
            "elements": [
                {
                    "type": "rich_text_section",
                    "elements": [
                        {
                            "type": "text",
                            "text": "a"
                        }
                    ]
                }
            ]
        }
    ],
    "team": "somecode",
    "thread_ts": "1679408970.932769",
    "reply_count": 1,
    "reply_users_count": 1,
    "latest_reply": "1679409008.483989",
    "reply_users": [
        "somecode"
    ],
    "is_locked": false,
    "subscribed": false
},
```

`blocks`, `team` fields가 nullable인 것을 확인하였습니다.

추가로
시간 범위 (분)를 상수로 변경했습니다.